### PR TITLE
fix: retry peer starting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "inter-scheme-proxy-adapter",
-  "version": "1.1.2-snapshot.0",
+  "version": "1.1.2-snapshot.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "inter-scheme-proxy-adapter",
-      "version": "1.1.2-snapshot.0",
+      "version": "1.1.2-snapshot.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@hapi/hapi": "^21.3.10",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "inter-scheme-proxy-adapter",
-  "version": "1.1.0-snapshot.2",
+  "version": "1.1.2-snapshot.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "inter-scheme-proxy-adapter",
-      "version": "1.1.0-snapshot.2",
+      "version": "1.1.2-snapshot.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@hapi/hapi": "^21.3.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "inter-scheme-proxy-adapter",
-  "version": "1.1.2-snapshot.0",
+  "version": "1.1.2-snapshot.1",
   "private": true,
   "description": "Schemes Proxy implementation (ISPA)",
   "author": "Eugen Klymniuk (geka-evk)",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "inter-scheme-proxy-adapter",
-  "version": "1.1.0-snapshot.2",
+  "version": "1.1.2-snapshot.0",
   "private": true,
   "description": "Schemes Proxy implementation (ISPA)",
   "author": "Eugen Klymniuk (geka-evk)",

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -97,7 +97,7 @@ export interface IHttpServer {
 }
 
 export interface IAuthClient {
-  startAccessTokenUpdates: (cb: (token: string) => void) => void;
+  startAccessTokenUpdates: (cb: (token: string) => void) => Promise<void>;
   stopUpdates: () => void;
   getOidcToken: () => Promise<OIDCToken>;
 }


### PR DESCRIPTION
This will not crash the server if a peer cannot be initialized, but will instead retry them independently each minute.